### PR TITLE
Fix retained screen-capture surfaces and bound image concurrency

### DIFF
--- a/IOSMCPPreferences.h
+++ b/IOSMCPPreferences.h
@@ -6,10 +6,14 @@
 #define IOS_MCP_DEFAULT_PORT 8090
 #define IOS_MCP_MIN_PORT 1024
 #define IOS_MCP_MAX_PORT 65535
+#define IOS_MCP_DEFAULT_MAX_CONCURRENT_SCREEN_TASKS 1
+#define IOS_MCP_MIN_CONCURRENT_SCREEN_TASKS 1
+#define IOS_MCP_MAX_CONCURRENT_SCREEN_TASKS 2
 #define IOS_MCP_PREFERENCES_DOMAIN @"com.witchan.ios-mcp.preferences"
 #define IOS_MCP_ENABLED_PREFERENCE_KEY @"enabled"
 #define IOS_MCP_PORT_PREFERENCE_KEY @"port"
 #define IOS_MCP_DEBUG_LOGGING_PREFERENCE_KEY @"debugLoggingEnabled"
+#define IOS_MCP_MAX_CONCURRENT_SCREEN_TASKS_PREFERENCE_KEY @"maxConcurrentScreenTasks"
 #define IOS_MCP_DARWIN_NOTIFICATION_START CFSTR("com.witchan.ios-mcp.control/start")
 #define IOS_MCP_DARWIN_NOTIFICATION_STOP CFSTR("com.witchan.ios-mcp.control/stop")
 
@@ -48,6 +52,23 @@ static inline uint16_t IOSMCPConfiguredPort(void) {
         CFRelease(value);
     }
     return port;
+}
+
+static inline NSInteger IOSMCPConfiguredMaxConcurrentScreenTasks(void) {
+    NSInteger limit = IOS_MCP_DEFAULT_MAX_CONCURRENT_SCREEN_TASKS;
+    CFPreferencesAppSynchronize((__bridge CFStringRef)IOS_MCP_PREFERENCES_DOMAIN);
+    CFPropertyListRef value = CFPreferencesCopyAppValue(
+        (__bridge CFStringRef)IOS_MCP_MAX_CONCURRENT_SCREEN_TASKS_PREFERENCE_KEY,
+        (__bridge CFStringRef)IOS_MCP_PREFERENCES_DOMAIN);
+    if (value) {
+        id preference = (__bridge id)value;
+        if ([preference respondsToSelector:@selector(integerValue)]) {
+            limit = [preference integerValue];
+        }
+        CFRelease(value);
+    }
+    return MAX(IOS_MCP_MIN_CONCURRENT_SCREEN_TASKS,
+               MIN(limit, IOS_MCP_MAX_CONCURRENT_SCREEN_TASKS));
 }
 
 static inline NSString *IOSMCPCurrentLANIPAddress(void) {

--- a/MCPServer.m
+++ b/MCPServer.m
@@ -10,6 +10,7 @@
 #import "LogManager.h"
 #import "OCRManager.h"
 #import "MCPLogger.h"
+#import "IOSMCPPreferences.h"
 #import <UIKit/UIKit.h>
 #import <sys/socket.h>
 #import <netinet/in.h>
@@ -655,6 +656,7 @@ static NSDictionary *MCPElementSummary(NSDictionary *element) {
 - (NSDictionary *)handleInitialize:(id)reqId params:(NSDictionary *)params;
 - (NSDictionary *)handleToolsList:(id)reqId;
 - (NSDictionary *)handleToolsCall:(id)reqId params:(NSDictionary *)params;
+- (NSDictionary *)performScreenTaskForRequest:(id)reqId task:(NSDictionary *(^)(void))task;
 - (NSDictionary *)lockedScreenGuardResponseForTool:(NSString *)toolName reqId:(id)reqId;
 - (NSDictionary *)executeButtonPress:(id)reqId button:(HIDButtonType)button args:(NSDictionary *)args label:(NSString *)label;
 - (BOOL)pressButtonSynchronously:(HIDButtonType)button duration:(NSTimeInterval)duration timeout:(NSTimeInterval)timeout error:(NSString **)error;
@@ -725,6 +727,7 @@ static NSDictionary *MCPElementSummary(NSDictionary *element) {
     int _serverSocket;
     dispatch_source_t _acceptSource;
     dispatch_queue_t _clientQueue;
+    dispatch_semaphore_t _screenTaskSemaphore;
     NSString *_sessionId;
     NSString *_negotiatedProtocolVersion;
 }
@@ -742,7 +745,12 @@ static NSDictionary *MCPElementSummary(NSDictionary *element) {
     self = [super init];
     if (self) {
         _serverSocket = -1;
-        _clientQueue = dispatch_queue_create("com.witchan.ios-mcp.client", DISPATCH_QUEUE_CONCURRENT);
+        dispatch_queue_attr_t clientAttributes =
+            dispatch_queue_attr_make_with_autorelease_frequency(DISPATCH_QUEUE_CONCURRENT,
+                                                                 DISPATCH_AUTORELEASE_FREQUENCY_WORK_ITEM);
+        _clientQueue = dispatch_queue_create("com.witchan.ios-mcp.client", clientAttributes);
+        _screenTaskSemaphore =
+            dispatch_semaphore_create(IOSMCPConfiguredMaxConcurrentScreenTasks());
         _sessionId = [[NSUUID UUID] UUIDString];
         _negotiatedProtocolVersion = MCP_PROTOCOL_VERSION_LATEST;
     }
@@ -808,7 +816,10 @@ static NSDictionary *MCPElementSummary(NSDictionary *element) {
     _port = port;
     _running = YES;
 
-    dispatch_queue_t queue = dispatch_queue_create("com.witchan.ios-mcp.accept", DISPATCH_QUEUE_CONCURRENT);
+    dispatch_queue_attr_t acceptAttributes =
+        dispatch_queue_attr_make_with_autorelease_frequency(DISPATCH_QUEUE_CONCURRENT,
+                                                             DISPATCH_AUTORELEASE_FREQUENCY_WORK_ITEM);
+    dispatch_queue_t queue = dispatch_queue_create("com.witchan.ios-mcp.accept", acceptAttributes);
     _acceptSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, sock, 0, queue);
 
     __weak typeof(self) weakSelf = self;
@@ -819,7 +830,9 @@ static NSDictionary *MCPElementSummary(NSDictionary *element) {
         if (client >= 0) {
             MCPSetCloseOnExec(client);
             dispatch_async(self->_clientQueue, ^{
-                [self handleClient:client];
+                @autoreleasepool {
+                    [self handleClient:client];
+                }
             });
         }
     });
@@ -2150,6 +2163,27 @@ static NSString *MCPLogId(id reqId) {
 
 #pragma mark - MCP: tools/call
 
+- (NSDictionary *)performScreenTaskForRequest:(id)reqId task:(NSDictionary *(^)(void))task {
+    if (!task) {
+        return [self mcpError:reqId code:-32603 message:@"Missing screen task"];
+    }
+
+    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
+    if (dispatch_semaphore_wait(_screenTaskSemaphore, timeout) != 0) {
+        return [self mcpError:reqId code:-32000 message:@"Timed out waiting for screen processing"];
+    }
+
+    NSDictionary *result = nil;
+    @try {
+        @autoreleasepool {
+            result = task();
+        }
+    } @finally {
+        dispatch_semaphore_signal(_screenTaskSemaphore);
+    }
+    return result;
+}
+
 - (NSDictionary *)handleToolsCall:(id)reqId params:(NSDictionary *)params {
     if (![params isKindOfClass:[NSDictionary class]]) {
         return [self mcpError:reqId code:-32602 message:@"Invalid params: expected object"];
@@ -2207,7 +2241,9 @@ static NSString *MCPLogId(id reqId) {
     else if ([toolName isEqualToString:@"get_screen_info"]) {
         return [self executeScreenInfo:reqId];
     } else if ([toolName isEqualToString:@"screenshot"]) {
-        return [self executeScreenshot:reqId args:args];
+        return [self performScreenTaskForRequest:reqId task:^{
+            return [self executeScreenshot:reqId args:args];
+        }];
     }
     // Clipboard tools
     else if ([toolName isEqualToString:@"get_clipboard"]) {
@@ -2233,8 +2269,17 @@ static NSString *MCPLogId(id reqId) {
     } else if ([toolName isEqualToString:@"get_element_at_point"]) {
         return [self executeGetElementAtPoint:reqId args:args];
     } else if ([toolName isEqualToString:@"ocr_screen"]) {
-        return [self executeOCRScreen:reqId args:args];
+        return [self performScreenTaskForRequest:reqId task:^{
+            return [self executeOCRScreen:reqId args:args];
+        }];
     } else if ([toolName isEqualToString:@"describe_screen"]) {
+        BOOL includesImageWork = [args[@"include_ocr"] boolValue] ||
+                                 [args[@"include_screenshot"] boolValue];
+        if (includesImageWork) {
+            return [self performScreenTaskForRequest:reqId task:^{
+                return [self executeDescribeScreen:reqId args:args];
+            }];
+        }
         return [self executeDescribeScreen:reqId args:args];
     }
     // Text input tools

--- a/OCRManager.m
+++ b/OCRManager.m
@@ -142,9 +142,11 @@ static CGImageRef OCRCreateDownsampled(CGImageRef src, CGFloat maxEdge) CF_RETUR
 
         // Downsample large captures before OCR (longest edge cap). Speeds up Vision on
         // high-res iPad screens; coordinates still map back via the logical image.size.
-        CGImageRef ocrImage = image.CGImage;
         CGImageRef downsampled = OCRCreateDownsampled(image.CGImage, 1600.0);
-        if (downsampled) ocrImage = downsampled;
+        CGImageRef ocrImage = downsampled ?: image.CGImage;
+        if (downsampled) {
+            image = nil;
+        }
 
         VNImageRequestHandler *handler = [[VNImageRequestHandler alloc] initWithCGImage:ocrImage options:@{}];
         NSError *performError = nil;

--- a/ScreenManager.m
+++ b/ScreenManager.m
@@ -14,7 +14,7 @@
 } while (0)
 
 typedef struct __IOSurface *IOSurfaceRef;
-typedef UIImage *(*UICreateScreenUIImageFunc)(void);
+typedef UIImage *(*UICreateScreenUIImageFunc)(void) NS_RETURNS_RETAINED;
 typedef CGImageRef (*UICreateCGImageFromIOSurfaceFunc)(IOSurfaceRef surface);
 typedef CGImageRef (*CARenderServerCaptureDisplayFunc)(uint32_t serverPort, CFStringRef displayName, CFDictionaryRef options);
 
@@ -26,6 +26,14 @@ static const NSUInteger kMCPScreenshotTargetBytes = 400 * 1024;
 static const CGFloat kMCPScreenshotInitialJPEGQuality = 0.82;
 static const CGFloat kMCPScreenshotMinimumJPEGQuality = 0.30;
 static const NSInteger kMCPScreenshotJPEGSearchPasses = 6;
+
+static NSData *MCPJPEGRepresentation(UIImage *image, CGFloat quality) {
+    NSData *data = nil;
+    @autoreleasepool {
+        data = UIImageJPEGRepresentation(image, quality);
+    }
+    return data;
+}
 
 /// Point-space target size for a pixel-space capture of `pixelSize`.
 ///
@@ -295,11 +303,13 @@ __attribute__((constructor)) static void _resolveScreenImageFunc(void) {
 - (NSDictionary *)takeScreenshotPayload {
     __block NSDictionary *payload = nil;
     dispatch_block_t block = ^{
-        payload = [self privateScreenshotPayload];
-        if (!payload) {
-            SCREEN_LOG(@"Private screenshot APIs produced no encodable image, falling back to window capture");
-            UIImage *image = [self fallbackScreenshotImage];
-            payload = [self payloadByEncodingImage:image source:@"window_capture"];
+        @autoreleasepool {
+            payload = [self privateScreenshotPayload];
+            if (!payload) {
+                SCREEN_LOG(@"Private screenshot APIs produced no encodable image, falling back to window capture");
+                UIImage *image = [self fallbackScreenshotImage];
+                payload = [self payloadByEncodingImage:image source:@"window_capture"];
+            }
         }
     };
 
@@ -315,10 +325,6 @@ __attribute__((constructor)) static void _resolveScreenImageFunc(void) {
     UIImage *image = nil;
     NSDictionary *payload = nil;
 
-    NSData *screenData = [ScreenManager getScreenDataWithQuantity:(NSInteger)round(kMCPScreenshotInitialJPEGQuality * 100.0)];
-    payload = [self payloadByEncodingImageData:screenData source:@"getScreenDataWithQuantity"];
-    if (payload) return payload;
-
     image = [self screenshotImageFromRenderServerCapture];
     payload = [self payloadByEncodingImage:image source:@"render_server"];
     if (payload) return payload;
@@ -329,6 +335,10 @@ __attribute__((constructor)) static void _resolveScreenImageFunc(void) {
 
     image = [self screenshotImageFromIOSurface];
     payload = [self payloadByEncodingImage:image source:@"createScreenIOSurface"];
+    if (payload) return payload;
+
+    NSData *screenData = [ScreenManager getScreenDataWithQuantity:(NSInteger)round(kMCPScreenshotInitialJPEGQuality * 100.0)];
+    payload = [self payloadByEncodingImageData:screenData source:@"getScreenDataWithQuantity"];
     if (payload) return payload;
 
     return nil;
@@ -400,9 +410,11 @@ __attribute__((constructor)) static void _resolveScreenImageFunc(void) {
 - (UIImage *)captureScreenImage {
     __block UIImage *image = nil;
     dispatch_block_t block = ^{
-        image = [self privateScreenshotImage];
-        if (!image) {
-            image = [self fallbackScreenshotImage];
+        @autoreleasepool {
+            image = [self privateScreenshotImage];
+            if (!image) {
+                image = [self fallbackScreenshotImage];
+            }
         }
     };
     if ([NSThread isMainThread]) {
@@ -589,11 +601,11 @@ __attribute__((constructor)) static void _resolveScreenImageFunc(void) {
 }
 
 - (NSData *)JPEGDataForImage:(UIImage *)image maxBytes:(NSUInteger)maxBytes {
-    NSData *bestData = UIImageJPEGRepresentation(image, kMCPScreenshotInitialJPEGQuality);
+    NSData *bestData = MCPJPEGRepresentation(image, kMCPScreenshotInitialJPEGQuality);
     if (!bestData) return nil;
     if (bestData.length <= maxBytes) return bestData;
 
-    NSData *minimumData = UIImageJPEGRepresentation(image, kMCPScreenshotMinimumJPEGQuality);
+    NSData *minimumData = MCPJPEGRepresentation(image, kMCPScreenshotMinimumJPEGQuality);
     if (!minimumData) return bestData;
     if (minimumData.length > maxBytes) return minimumData;
 
@@ -605,7 +617,7 @@ __attribute__((constructor)) static void _resolveScreenImageFunc(void) {
     CGFloat high = kMCPScreenshotInitialJPEGQuality;
     for (NSInteger pass = 0; pass < kMCPScreenshotJPEGSearchPasses; pass++) {
         CGFloat quality = (low + high) / 2.0;
-        NSData *candidate = UIImageJPEGRepresentation(image, quality);
+        NSData *candidate = MCPJPEGRepresentation(image, quality);
         if (!candidate) break;
 
         if (candidate.length > maxBytes) {

--- a/prefs/Resources/Root.plist
+++ b/prefs/Resources/Root.plist
@@ -57,6 +57,36 @@
 		<dict>
 			<key>cell</key>
 			<string>PSGroupCell</string>
+			<key>label</key>
+			<string>图像处理</string>
+			<key>footerText</key>
+			<string>限制截图和 OCR 同时处理的任务数。1 更节省内存，2 可提高高内存设备的吞吐量。修改后需要重启 SpringBoard。</string>
+		</dict>
+		<dict>
+			<key>cell</key>
+			<string>PSSegmentCell</string>
+			<key>default</key>
+			<integer>1</integer>
+			<key>defaults</key>
+			<string>com.witchan.ios-mcp.preferences</string>
+			<key>key</key>
+			<string>maxConcurrentScreenTasks</string>
+			<key>label</key>
+			<string>并发任务</string>
+			<key>validTitles</key>
+			<array>
+				<string>1</string>
+				<string>2</string>
+			</array>
+			<key>validValues</key>
+			<array>
+				<integer>1</integer>
+				<integer>2</integer>
+			</array>
+		</dict>
+		<dict>
+			<key>cell</key>
+			<string>PSGroupCell</string>
 			<key>id</key>
 			<string>debugLogGroup</string>
 			<key>label</key>


### PR DESCRIPTION
## Summary

Repeated screenshot and OCR requests could retain IOSurface-backed capture images inside SpringBoard, causing memory usage to grow continuously.

This change:

- Corrects ARC ownership metadata for retained screen-capture images.
- Moves the legacy re-encode capture path to the final fallback position.
- Adds autorelease boundaries around request handling, capture, and JPEG encoding.
- Releases the original full-resolution OCR image after creating an independent downsampled image.
- Limits concurrent image-processing tasks to reduce transient memory pressure.
- Adds a setting for one or two concurrent screen tasks, defaulting to one.

The public MCP tool schemas, screenshot format, and point-space coordinate metadata remain unchanged. Existing capture fallbacks are retained.

## Build environment

- macOS 26.3.1
- Xcode 26.6
- Apple Clang 21.0.0
- iPhoneOS 16.5 SDK
- roothide/theos commit `88506b2c22e9e07dd4ed055f23c9e398a117a2c7`
- Rootless arm64 and arm64e targets

Both the tweak and preference bundle compiled successfully.

## Runtime environment

- iOS 16.3.1
- Dopamine 2.4.9
- Rootless jailbreak

Runtime validation was performed on this environment. Other iOS versions were not runtime-tested, but the existing fallback paths remain available.

## Test procedure

1. Restart SpringBoard and record its initial footprint.
2. Run 50 sequential `screenshot` requests.
3. Run 20 sequential `ocr_screen` requests.
4. Run 12 mixed screenshot/OCR requests from four client workers.
5. Wait 30 seconds and record the retained footprint.
6. Record SpringBoard memory using `/usr/bin/footprint` after each phase.

## Memory observations

| Phase | 1.2.3 | Patched |
|---|---:|---:|
| Initial | 60 MB | 63 MB |
| After 50 screenshots | 595 MB | 67 MB |
| After 20 OCR requests | 843 MB | 104 MB |
| After mixed workload | 970 MB | 107 MB |
| After 30 seconds idle | 967 MB | 102 MB |
| Peak footprint | 1,040 MB | 144 MB |

All 82 requests completed successfully in both runs.

The IOSurface category reached approximately 861 MB on 1.2.3. With the patch, it remained at 896 KB throughout the full test.

## Isolation check

A build containing only autorelease boundaries, OCR cleanup, and concurrency limiting still grew from 60 MB to 171 MB after ten screenshots, with IOSurface reaching 106 MB.

After adding the capture ownership correction, the same ten-request test changed from 61 MB to 67 MB and returned to 63-64 MB after idle, while IOSurface remained at 896 KB.

## Concurrency trade-off

With the default limit of one screen task, mixed four-worker latency increased from 1.397 seconds to 2.429 seconds on average. Screenshot and sequential OCR latency remained effectively unchanged.

Devices with more available memory can select two concurrent screen tasks in Settings.
